### PR TITLE
Added cemu, removed winlator

### DIFF
--- a/es_find_rules.xml
+++ b/es_find_rules.xml
@@ -51,16 +51,10 @@
 	    <entry>dev.suyu.suyu_emu/dev.suyu.suyu_emu.activities.EmulationActivity</entry>
 	</rule>
     </emulator>
-    <emulator name="WINLATOR-GLIBC">
-        <!-- Winlator Cmod Glibc -->
+    <emulator name="CEMU">
+        <!-- Nintendo Wii U emulator Cemu -->
         <rule type="androidpackage">
-            <entry>com.winlator/.XServerDisplayActivity</entry>
-        </rule>
-    </emulator>
-    <emulator name="WINLATOR-PROOT">
-        <!-- Winlator Cmod Proot -->
-        <rule type="androidpackage">
-            <entry>com.cmodded.winlator/com.winlator.XServerDisplayActivity</entry>
+            <entry>info.cemu.Cemu/info.cemu.Cemu.emulation.EmulationActivity</entry>
         </rule>
     </emulator>
 </ruleList>

--- a/es_systems.xml
+++ b/es_systems.xml
@@ -172,14 +172,13 @@
         <platform>switch</platform>
         <theme>switch</theme>
     </system>
-    <system>
-        <name>windows</name>
-        <fullname>Microsoft Windows</fullname>
-        <path>/storage/emulated/0/Download/Winlator/Frontend</path>
-        <extension>.desktop</extension>
-        <command label="Winlator Cmod Glibc">%EMULATOR_WINLATOR-GLIBC% %ACTIVITY_CLEAR_TASK% %ACTIVITY_CLEAR_TOP% %EXTRA_shortcut_path%=%ROM%</command>
-        <command label="Winlator Cmod Proot">%EMULATOR_WINLATOR-PROOT% %ACTIVITY_CLEAR_TASK% %ACTIVITY_CLEAR_TOP% %EXTRA_shortcut_path%=%ROM%</command>
-        <platform>pcwindows</platform>
-        <theme>windows</theme>
+	<system>
+        <name>wiiu</name>
+        <fullname>Nintendo Wii U</fullname>
+        <path>%ROMPATH%\wiiu</path>
+        <extension>.elf .ELF .rpx .RPX .tmd .TMD .wua .WUA .wud .WUD .wuhb .WUHB .wux .WUX</extension>
+        <command label="Cemu (Standalone)">%EMULATOR_CEMU% %DATA%=%ROMSAF%</command>
+        <platform>wiiu</platform>
+        <theme>wiiu</theme>
     </system>
 </systemList>


### PR DESCRIPTION
Cemu requires latest build to work - https://github.com/SSimco/Cemu/releases/tag/32795e1

Winlator added to ES-DE 3.1.0 so removed.