### PR TITLE
Add Moonlight streaming support with Artemis

### DIFF
--- a/es_find_rules.xml
+++ b/es_find_rules.xml
@@ -13,11 +13,13 @@
             <entry>aenu.ax360e/aenu.ax360e.EmulatorActivity</entry>
             <entry>aenu.ax360e.free/aenu.ax360e.EmulatorActivity</entry>
         </rule>
-    </emulator>    <emulator name="Artemis">
+    </emulator>
+    <emulator name="Artemis">
         <rule type="androidpackage">
-			<entry>com.limelight.noir/com.limelight.ShortcutTrampoline</entry>
+            <entry>com.limelight.noir/com.limelight.ShortcutTrampoline</entry>
         </rule>
-    </emulator>    <emulator name="BENJI-SC">
+    </emulator>
+    <emulator name="BENJI-SC">
         <!-- Nintendo Switch emulator Benji-SC -->
         <rule type="androidpackage">
             <entry>org.benjisc.android/org.kenjinx.android.MainActivity</entry>

--- a/es_find_rules.xml
+++ b/es_find_rules.xml
@@ -13,8 +13,11 @@
             <entry>aenu.ax360e/aenu.ax360e.EmulatorActivity</entry>
             <entry>aenu.ax360e.free/aenu.ax360e.EmulatorActivity</entry>
         </rule>
-    </emulator>
-    <emulator name="BENJI-SC">
+    </emulator>    <emulator name="Artemis">
+        <rule type="androidpackage">
+			<entry>com.limelight.noir/com.limelight.ShortcutTrampoline</entry>
+        </rule>
+    </emulator>    <emulator name="BENJI-SC">
         <!-- Nintendo Switch emulator Benji-SC -->
         <rule type="androidpackage">
             <entry>org.benjisc.android/org.kenjinx.android.MainActivity</entry>

--- a/es_systems.xml
+++ b/es_systems.xml
@@ -164,6 +164,15 @@
         <theme>model3</theme>
     </system>
     <system>
+        <name>moonlight</name>
+        <fullname>Moonlight Game Streaming</fullname>
+        <path>%ROMPATH%/moonlight</path>
+        <extension>.art</extension>
+		<command label="Artemis">%EMULATOR_Artemis% %ACTION%=android.intent.action.VIEW %DATA%=%ROMSAF%</command>
+        <platform>moonlight</platform>
+        <theme>moonlight</theme>
+    </system>
+    <system>
         <name>msu-md</name>
         <fullname>Sega Mega Drive MSU</fullname>
         <path>%ROMPATH%/msu-md</path>


### PR DESCRIPTION
Introduce support for Moonlight Game Streaming by adding a new system configuration and integrating the Artemis launcher. Tested and verified launching exported moonlight games directly from ES-DE, which is pretty neat and should be supported out of the box. I think it would a meaningful addition to many as usage of Artemis for moonlight streaming is widespread and actually pretty useful. Also supported by Daijisho and Beacon.