### PR TITLE
Add missing ARMSX2 find rule

### DIFF
--- a/es_find_rules.xml
+++ b/es_find_rules.xml
@@ -7,6 +7,12 @@
             <entry>com.nanodata.armsx/com.armsx2.Main</entry>
         </rule>
     </emulator>
+	<emulator name="ARMSX2">
+        <!-- Sony PlayStation 2 emulator ARMSX2-->
+        <rule type="androidpackage">
+            <entry>com.armsx2/.Main</entry>
+        </rule>
+    </emulator>
 	<emulator name="ARMSX3">
         <!-- Sony PlayStation 3 emulator ARMSX3-->
         <rule type="androidpackage">


### PR DESCRIPTION
## Summary
- `es_systems.xml` references `%EMULATOR_ARMSX2%` for the "ARMSX2 (Standalone)" PS2 command, but `es_find_rules.xml` only defines `ARMSX2R` (ARMSX2 Refresh) — there's no rule for plain `ARMSX2`.
- Without a matching rule, ES-DE falls back to its own built-in default, which only recognizes the legacy package `come.nanodata.armsx2`. The currently distributed ARMSX2 build installs as `com.armsx2` with launcher activity `.Main`, so it never matches and the command fails with "Couldn't launch game, emulator not found" even when ARMSX2 is installed and working correctly.
- Added a rule for `com.armsx2/.Main`, mirroring the existing `ARMSX2R` entry (same package/activity), since both point at the same current build.

## Test plan
- [x] Confirmed via `adb shell dumpsys package com.armsx2` that `com.armsx2/.Main` declares an intent filter for `android.intent.action.VIEW` with `content`/`file` data schemes, matching what the "ARMSX2 (Standalone)" command requires.
- [x] Applied the identical change locally on a Retroid Pocket Mini V2, fully restarted ES-DE, and confirmed a PS2 game now launches successfully via "ARMSX2 (Standalone)".